### PR TITLE
switch to Press theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'karma_sphinx_theme'
+html_theme = 'press'
 html_title = project
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-karma_sphinx_theme
+sphinx-press-theme
 sphinx-copybutton


### PR DESCRIPTION
Now we have support for Sphinx 3+, we can choose from a wider range of themes. This PR updates the documentation to use the Press theme.